### PR TITLE
Escape . when converting sheets to datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.2](https://github.com/dataiku/dss-plugin-excel-sheet-importer/releases/tag/v1.1.2) - 2024-07
+- Support . in sheet name (replaced by a _ in the Flow)
+
 ## [v1.1.1](https://github.com/dataiku/dss-plugin-excel-sheet-importer/releases/tag/v1.1.1) - 2023-07
 - Use folder API instead of local folders
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "excel-sheet-importer",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "meta": {
         "label": "Excel sheet importer",
         "description": "Create one dataset per sheet from an Excel file stored in a folder.",

--- a/python-runnables/macro-excel-importer/runnable.py
+++ b/python-runnables/macro-excel-importer/runnable.py
@@ -75,6 +75,7 @@ class MyRunnable(Runnable):
                 title = title.replace(')', '')
                 title = title.replace('(', '')
                 title = title.replace('/', '_')
+                title = title.replace('.', '_')
 
                 create_dataset = True
                 if title in datasets_in_project:

--- a/python-runnables/macro-excel-importer/runnable.py
+++ b/python-runnables/macro-excel-importer/runnable.py
@@ -4,6 +4,7 @@ import openpyxl
 import time
 from dataiku.runnables import Runnable, ResultTable
 from io import BytesIO
+import re
 
 
 class MyRunnable(Runnable):
@@ -70,12 +71,10 @@ class MyRunnable(Runnable):
                 if not file_name.split(".")[0] in title:
                     title = file_name.split(".")[0] + "_" + sheet
 
-                # Convert whitespace to underscores, remove unacceptable characters
-                title = '_'.join(title.split())
-                title = title.replace(')', '')
-                title = title.replace('(', '')
-                title = title.replace('/', '_')
-                title = title.replace('.', '_')
+                # Replace all characters that are not allowed in a dataset name by _
+                # Allowed characters are a-z A-Z 0-9 - _
+                title = title.encode('ascii', errors='replace').decode('ascii') # replace all non ascii characters with a questionmark (which will become a _)
+                title = re.sub(r"[^\w\-_]", "_", title)
 
                 create_dataset = True
                 if title in datasets_in_project:

--- a/python-runnables/macro-excel-importer/runnable.py
+++ b/python-runnables/macro-excel-importer/runnable.py
@@ -4,7 +4,6 @@ import openpyxl
 import time
 from dataiku.runnables import Runnable, ResultTable
 from io import BytesIO
-import re
 
 
 class MyRunnable(Runnable):
@@ -71,10 +70,12 @@ class MyRunnable(Runnable):
                 if not file_name.split(".")[0] in title:
                     title = file_name.split(".")[0] + "_" + sheet
 
-                # Replace all characters that are not allowed in a dataset name by _
-                # Allowed characters are a-z A-Z 0-9 - _
-                title = title.encode('ascii', errors='replace').decode('ascii') # replace all non ascii characters with a questionmark (which will become a _)
-                title = re.sub(r"[^\w\-_]", "_", title)
+                # Convert whitespace to underscores, remove unacceptable characters
+                title = '_'.join(title.split())
+                title = title.replace(')', '')
+                title = title.replace('(', '')
+                title = title.replace('/', '_')
+                title = title.replace('.', '_')
 
                 create_dataset = True
                 if title in datasets_in_project:


### PR DESCRIPTION
. in sheet names will be replaced with _. 
Other characters non-compliant with dataset naming guidelines will not be affected in order not to break any existing flows. If that stance changes we could add this snippet to filter out unwanted characters: 

```
 # replace all non ascii characters with a questionmark (which will become a _)
title = title.encode('ascii', errors='replace').decode('ascii')
title = re.sub(r"[^\w\-_]", "_", title)
```